### PR TITLE
Create robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Blocking indexing of the subdomain, they prefer to have the site only show up in search results from the main domain.